### PR TITLE
Update of existing access control handling, query class add

### DIFF
--- a/smorest_crud/__init__.py
+++ b/smorest_crud/__init__.py
@@ -58,7 +58,7 @@ class CRUD(object):
             else:
                 raise Exception("CRUD_GET_USER not found in configuration")
 
-        # checking if CRUD_KEY_COLUMN is present in configs to replace default value
+        # checking if CRUD_KEY_COLUMN is present in configs to replace the default value
         if config_keys["key_attr"] in app.config:
             self.key_attr = app.config[config_keys["key_attr"]]
 

--- a/smorest_crud/__init__.py
+++ b/smorest_crud/__init__.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 # access initialized extension
 _crud = LocalProxy(lambda: current_app.extensions["crud"])
 
-config_keys = dict(get_user="CRUD_GET_USER")
+config_keys = dict(get_user="CRUD_GET_USER", key_attr="CRUD_KEY_COLUMN")
 
 
 class CRUD(object):
@@ -29,12 +29,14 @@ class CRUD(object):
             CRUD_GET_USER=get_current_user,
             CRUD_ACCESS_CHECKS_ENABLED=True,
             SECRET_KEY="wnt2die",
+            CRUD_KEY_COLUMN="extid",
         )
     """
 
     db: SQLAlchemy
     app: Flask
     get_user: Optional[Callable]
+    key_attr: str = "id"
     access_control_enabled: bool
 
     def __init__(self, app=None):
@@ -55,6 +57,10 @@ class CRUD(object):
                 self.get_user = app.config["CRUD_GET_USER"]
             else:
                 raise Exception("CRUD_GET_USER not found in configuration")
+
+        # checking if CRUD_KEY_COLUMN is present in configs to replace default value
+        if config_keys["key_attr"] in app.config:
+            self.key_attr = app.config[config_keys["key_attr"]]
 
         # save sqla db object for later
         self.db = app.extensions["sqlalchemy"].db

--- a/smorest_crud/__init__.py
+++ b/smorest_crud/__init__.py
@@ -1,7 +1,7 @@
 from flask import current_app
 from werkzeug.local import LocalProxy
 import logging
-from flask_sqlalchemy import SQLAlchemy, BaseQuery
+from flask_sqlalchemy import SQLAlchemy
 from flask import Flask
 from typing import Optional, Callable
 
@@ -10,47 +10,7 @@ log = logging.getLogger(__name__)
 # access initialized extension
 _crud = LocalProxy(lambda: current_app.extensions["crud"])
 
-
-class AccessControlUser:
-    """A model mixin to implement access checks for a given model/user.
-
-    Required on all models for views with access checks enabled.
-
-    Example::
-
-        class Pet(Model, AccessControlUser):
-            @classmethod
-            def query_for_user(cls, user) -> Optional[BaseQuery]:
-                return cls.query.filter_by(owner=user)
-
-            def user_can_read(self, user) -> bool:
-                return self.user_can_write(user) or self.owner.id == user.id
-
-            def user_can_write(self, user) -> bool:
-                return user.is_admin  # only administrators can edit pets
-    """
-
-    @classmethod
-    def query_for_user(cls, user: "AccessControlUser") -> Optional[BaseQuery]:
-        """Filter list of items for `user`, or None if disallowed."""
-        return None
-
-    def user_can_read(self, user: "AccessControlUser") -> bool:
-        """Check if `user` is allowed to access this object at all.
-
-        Defaults to calling `self.user_can_write(user)`.
-        """
-        return self.user_can_write(user)
-
-    def user_can_write(self, user: "AccessControlUser") -> bool:
-        """Check if `user` can make any modifications to this object (update, delete)."""
-        raise NotImplementedError(
-            f"user_can_write(self, user) not implemented on {self}"
-        )
-
-    def user_can_create(self, user: "AccessControlUser", args: Optional[dict]) -> bool:
-        """Check if `user` is allowed to create."""
-        return True
+config_keys = dict(get_user="CRUD_GET_USER")
 
 
 class CRUD(object):
@@ -106,5 +66,19 @@ class CRUD(object):
 
 
 from smorest_crud.view import ResourceView, CollectionView
+from smorest_crud.access_control import (
+    AccessControlUser,
+    AccessControlQuery,
+    get_for_current_user_or_404,
+    query_for_current_user
+)
 
-__all__ = ("ResourceView", "CollectionView", "CRUD", "AccessControlUser")
+__all__ = (
+    "ResourceView",
+    "CollectionView",
+    "CRUD",
+    "AccessControlUser",
+    "AccessControlQuery",
+    "get_for_current_user_or_404",
+    "query_for_current_user"
+)

--- a/smorest_crud/__init__.py
+++ b/smorest_crud/__init__.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 # access initialized extension
 _crud = LocalProxy(lambda: current_app.extensions["crud"])
 
-config_keys = dict(get_user="CRUD_GET_USER", key_attr="CRUD_KEY_COLUMN")
+config_keys = dict(get_user="CRUD_GET_USER", key_attr="CRUD_DEFAULT_KEY_COLUMN")
 
 
 class CRUD(object):
@@ -29,7 +29,7 @@ class CRUD(object):
             CRUD_GET_USER=get_current_user,
             CRUD_ACCESS_CHECKS_ENABLED=True,
             SECRET_KEY="wnt2die",
-            CRUD_KEY_COLUMN="extid",
+            CRUD_DEFAULT_KEY_COLUMN="extid",
         )
     """
 
@@ -58,7 +58,7 @@ class CRUD(object):
             else:
                 raise Exception("CRUD_GET_USER not found in configuration")
 
-        # checking if CRUD_KEY_COLUMN is present in configs to replace the default value
+        # checking if CRUD_DEFAULT_KEY_COLUMN is present in configs to replace the default value
         if config_keys["key_attr"] in app.config:
             self.key_attr = app.config[config_keys["key_attr"]]
 
@@ -76,7 +76,7 @@ from smorest_crud.access_control import (
     AccessControlUser,
     AccessControlQuery,
     get_for_current_user_or_404,
-    query_for_current_user
+    query_for_current_user,
 )
 
 __all__ = (
@@ -86,5 +86,5 @@ __all__ = (
     "AccessControlUser",
     "AccessControlQuery",
     "get_for_current_user_or_404",
-    "query_for_current_user"
+    "query_for_current_user",
 )

--- a/smorest_crud/access_control/__init__.py
+++ b/smorest_crud/access_control/__init__.py
@@ -1,0 +1,4 @@
+from smorest_crud.access_control.utils import get_for_current_user_or_404, query_for_current_user
+from smorest_crud.access_control.models import AccessControlUser, AccessControlQuery
+
+__all__ = ("AccessControlUser", "AccessControlQuery", "get_for_current_user_or_404", "query_for_current_user")

--- a/smorest_crud/access_control/__init__.py
+++ b/smorest_crud/access_control/__init__.py
@@ -1,4 +1,12 @@
-from smorest_crud.access_control.utils import get_for_current_user_or_404, query_for_current_user
+from smorest_crud.access_control.utils import (
+    get_for_current_user_or_404,
+    query_for_current_user,
+)
 from smorest_crud.access_control.models import AccessControlUser, AccessControlQuery
 
-__all__ = ("AccessControlUser", "AccessControlQuery", "get_for_current_user_or_404", "query_for_current_user")
+__all__ = (
+    "AccessControlUser",
+    "AccessControlQuery",
+    "get_for_current_user_or_404",
+    "query_for_current_user",
+)

--- a/smorest_crud/access_control/models.py
+++ b/smorest_crud/access_control/models.py
@@ -1,0 +1,77 @@
+from typing import Optional, TypeVar, Type, Generic, Union
+
+from flask_sqlalchemy import BaseQuery, Model
+from flask import abort
+
+T = TypeVar("T", bound=Model)
+
+
+class AccessControlQuery(BaseQuery):
+    """Base query class to use for access restriction."""
+
+    def query_for_user(self, user: Type[T]) -> Type["AccessControlQuery"]:
+        """Access control query for the given user instance."""
+        raise NotImplementedError()
+
+
+class AccessControlUser(Generic[T]):
+    """A model mixin to implement access checks for a given model/user.
+
+    Required on all models for views with access checks enabled.
+
+    Example::
+
+        class PetQuery(AccessControlQuery):
+            def query_for_user(self, user) -> "PetQuery":
+                return self.filter_by(owner=user)
+
+        class Pet(Model, AccessControlUser):
+            query_class = PetQuery
+
+            def user_can_read(self, user) -> bool:
+                return self.user_can_write(user) or self.owner.id == user.id
+
+            def user_can_write(self, user) -> bool:
+                return user.is_admin  # only administrators can edit pets
+    """
+    query_class: Type[AccessControlQuery]
+
+    @classmethod
+    def query_for_user(cls, user: "AccessControlUser") -> Optional[AccessControlQuery]:
+        """Filter list of items for `user`, or None if disallowed."""
+        if not hasattr(cls.query, "query_for_user"):
+            return None
+        return cls.query.query_for_user(user)
+
+    @classmethod
+    def get_for_user_or_404(cls: Type[Model], user: Type[T], id_value: Union[str, int], key_attr: str = "extid") -> T:
+        """
+        Get instance by key if user allowed to read.
+        :param user: user instance to check access for
+        :param id_value: value of the key attribute for filtering
+        :param key_attr: name of the key attribute for filtering, extid be default
+        """
+        if not hasattr(cls, key_attr):
+            raise AttributeError(f"class {cls.__name__} doesn't have attribute {key_attr}")
+
+        obj = cls.query.query_for_user(user).filter(getattr(cls, key_attr) == id_value).one_or_none()
+        if obj is None:
+            abort(404)
+        return obj
+
+    def user_can_read(self, user: "AccessControlUser") -> bool:
+        """Check if `user` is allowed to access this object at all.
+
+        Defaults to calling `self.user_can_write(user)`.
+        """
+        return self.user_can_write(user)
+
+    def user_can_write(self, user: "AccessControlUser") -> bool:
+        """Check if `user` can make any modifications to this object (update, delete)."""
+        raise NotImplementedError(
+            f"user_can_write(self, user) not implemented on {self}"
+        )
+
+    def user_can_create(self, user: "AccessControlUser", args: Optional[dict]) -> bool:
+        """Check if `user` is allowed to create."""
+        return True

--- a/smorest_crud/access_control/models.py
+++ b/smorest_crud/access_control/models.py
@@ -1,4 +1,5 @@
 from typing import Optional, TypeVar, Type, Generic, Union
+from smorest_crud import _crud
 
 from flask_sqlalchemy import BaseQuery, Model
 from flask import abort
@@ -44,17 +45,18 @@ class AccessControlUser(Generic[T]):
         return cls.query.query_for_user(user)
 
     @classmethod
-    def get_for_user_or_404(cls: Type[Model], user: Type[T], id_value: Union[str, int], key_attr: str = "extid") -> T:
+    def get_for_user_or_404(cls: Type[Model], user: Type[T], id_value: Union[str, int]) -> T:
         """
         Get instance by key if user allowed to read.
         :param user: user instance to check access for
         :param id_value: value of the key attribute for filtering
-        :param key_attr: name of the key attribute for filtering, extid be default
         """
-        if not hasattr(cls, key_attr):
-            raise AttributeError(f"class {cls.__name__} doesn't have attribute {key_attr}")
+        if not hasattr(cls, _crud.key_attr):
+            raise AttributeError(
+                f"class {cls.__name__} doesn't have attribute {_crud.key_attr}. Try to set CRUD_KEY_COLUMN in configs."
+            )
 
-        obj = cls.query.query_for_user(user).filter(getattr(cls, key_attr) == id_value).one_or_none()
+        obj = cls.query.query_for_user(user).filter(getattr(cls, _crud.key_attr) == id_value).one_or_none()
         if obj is None:
             abort(404)
         return obj

--- a/smorest_crud/access_control/models.py
+++ b/smorest_crud/access_control/models.py
@@ -35,6 +35,7 @@ class AccessControlUser(Generic[T]):
             def user_can_write(self, user) -> bool:
                 return user.is_admin  # only administrators can edit pets
     """
+
     query_class: Type[AccessControlQuery]
 
     @classmethod
@@ -45,7 +46,9 @@ class AccessControlUser(Generic[T]):
         return cls.query.query_for_user(user)
 
     @classmethod
-    def get_for_user_or_404(cls: Type[Model], user: Type[T], id_value: Union[str, int]) -> T:
+    def get_for_user_or_404(
+        cls: Type[Model], user: Type[T], id_value: Union[str, int]
+    ) -> T:
         """
         Get instance by key if user allowed to read.
         :param user: user instance to check access for
@@ -53,10 +56,14 @@ class AccessControlUser(Generic[T]):
         """
         if not hasattr(cls, _crud.key_attr):
             raise AttributeError(
-                f"class {cls.__name__} doesn't have attribute {_crud.key_attr}. Try to set CRUD_KEY_COLUMN in configs."
+                f"class {cls.__name__} doesn't have attribute {_crud.key_attr}. Try to set CRUD_DEFAULT_KEY_COLUMN in configs."
             )
 
-        obj = cls.query.query_for_user(user).filter(getattr(cls, _crud.key_attr) == id_value).one_or_none()
+        obj = (
+            cls.query.query_for_user(user)
+            .filter(getattr(cls, _crud.key_attr) == id_value)
+            .one_or_none()
+        )
         if obj is None:
             abort(404)
         return obj

--- a/smorest_crud/access_control/utils.py
+++ b/smorest_crud/access_control/utils.py
@@ -7,14 +7,13 @@ from smorest_crud.access_control.models import AccessControlUser, AccessControlQ
 T = TypeVar("T", bound=AccessControlUser)
 
 
-def get_for_current_user_or_404(model: Type[T], id_value: Union[str, int], key_attr: str = "extid") -> Optional[T]:
+def get_for_current_user_or_404(model: Type[T], id_value: Union[str, int]) -> Optional[T]:
     """
     Get an object by unique column and check if the current user can read it.
     :param model: date base model of the instance
     :param id_value: the id value of the interested instance
-    :param key_attr: name of the key attribute for filtering, extid be default
     """
-    return model.get_for_user_or_404(_get_current_user(), id_value, key_attr=key_attr)
+    return model.get_for_user_or_404(_get_current_user(), id_value)
 
 
 def query_for_current_user(model: Type[T]) -> AccessControlQuery:

--- a/smorest_crud/access_control/utils.py
+++ b/smorest_crud/access_control/utils.py
@@ -7,7 +7,9 @@ from smorest_crud.access_control.models import AccessControlUser, AccessControlQ
 T = TypeVar("T", bound=AccessControlUser)
 
 
-def get_for_current_user_or_404(model: Type[T], id_value: Union[str, int]) -> Optional[T]:
+def get_for_current_user_or_404(
+    model: Type[T], id_value: Union[str, int]
+) -> Optional[T]:
     """
     Get an object by unique column and check if the current user can read it.
     :param model: date base model of the instance

--- a/smorest_crud/access_control/utils.py
+++ b/smorest_crud/access_control/utils.py
@@ -1,0 +1,32 @@
+from typing import Optional, TypeVar, Type, Union
+
+from smorest_crud import _crud, config_keys
+
+from smorest_crud.access_control.models import AccessControlUser, AccessControlQuery
+
+T = TypeVar("T", bound=AccessControlUser)
+
+
+def get_for_current_user_or_404(model: Type[T], id_value: Union[str, int], key_attr: str = "extid") -> Optional[T]:
+    """
+    Get an object by unique column and check if the current user can read it.
+    :param model: date base model of the instance
+    :param id_value: the id value of the interested instance
+    :param key_attr: name of the key attribute for filtering, extid be default
+    """
+    return model.get_for_user_or_404(_get_current_user(), id_value, key_attr=key_attr)
+
+
+def query_for_current_user(model: Type[T]) -> AccessControlQuery:
+    """
+    Get query for the current authorized user using access checks.
+    :param model: date base model of the instance
+    """
+    return model.query.query_for_user(_get_current_user())
+
+
+def _get_current_user() -> Optional[T]:
+    get_user_func = _crud.app.config.get(config_keys["get_user"])
+    if not get_user_func:
+        return None
+    return get_user_func()

--- a/smorest_crud/test/conftest.py
+++ b/smorest_crud/test/conftest.py
@@ -1,5 +1,5 @@
 from smorest_crud.test.app import create_app, db as db_
-from smorest_crud.test.app.model import Pet, Human
+from smorest_crud.test.app.model import Pet, Human, Car
 import pytest
 from pytest_factoryboy import register
 import factory
@@ -64,3 +64,11 @@ class PetFactory(factory.Factory):
     edible = factory.LazyAttribute(lambda x: random.choice((True, False)))
 
     human = factory.SubFactory(HumanFactory)
+
+
+@register
+class CarFactory(factory.Factory):
+    class Meta:
+        model = Car
+
+    owner = factory.SubFactory(HumanFactory)

--- a/smorest_crud/test/test_access_controls.py
+++ b/smorest_crud/test/test_access_controls.py
@@ -86,36 +86,49 @@ def test_get_for_current_user_or_404(car_factory, db):
     db.session.commit()
 
     # getting instance with success
-    with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock:
+    with patch(
+        "smorest_crud.access_control.utils._get_current_user"
+    ) as get_current_user_mock:
         get_current_user_mock.return_value = car_1.owner
         car = get_for_current_user_or_404(Car, car_1.id)
         assert car
         assert car == car_1
 
-    with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock:
+    with patch(
+        "smorest_crud.access_control.utils._get_current_user"
+    ) as get_current_user_mock:
         get_current_user_mock.return_value = car_2.owner
         car = get_for_current_user_or_404(Car, car_2.id)
         assert car
         assert car == car_2
 
     # getting not accessible instance with aborting
-    with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock, \
-            patch("smorest_crud.access_control.models.abort") as abort_mock:
+    with patch(
+        "smorest_crud.access_control.utils._get_current_user"
+    ) as get_current_user_mock, patch(
+        "smorest_crud.access_control.models.abort"
+    ) as abort_mock:
         get_current_user_mock.return_value = car_2.owner
         car = get_for_current_user_or_404(Car, car_1.id)
         assert car is None
         assert abort_mock.called_once_with(404)
 
-    with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock, \
-            patch("smorest_crud.access_control.models.abort") as abort_mock:
+    with patch(
+        "smorest_crud.access_control.utils._get_current_user"
+    ) as get_current_user_mock, patch(
+        "smorest_crud.access_control.models.abort"
+    ) as abort_mock:
         get_current_user_mock.return_value = car_1.owner
         car = get_for_current_user_or_404(Car, car_2.id)
         assert car is None
         assert abort_mock.called_once_with(404)
 
     # trying to get not existing instance
-    with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock, \
-            patch("smorest_crud.access_control.models.abort") as abort_mock:
+    with patch(
+        "smorest_crud.access_control.utils._get_current_user"
+    ) as get_current_user_mock, patch(
+        "smorest_crud.access_control.models.abort"
+    ) as abort_mock:
         get_current_user_mock.return_value = car_1.owner
         car = get_for_current_user_or_404(Car, car_1.id + 10)
         assert car is None
@@ -131,8 +144,9 @@ def test_get_for_current_user_or_404_no_attr(car_factory, db, app):
     app.extensions["crud"].key_attr = "extid"
 
     # trying to get not existing column
-    with pytest.raises(AttributeError) as e, \
-            patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock:
+    with pytest.raises(AttributeError) as e, patch(
+        "smorest_crud.access_control.utils._get_current_user"
+    ) as get_current_user_mock:
         get_current_user_mock.return_value = car.owner
         get_for_current_user_or_404(Car, car.id)
         assert "extid" in e  # checking column name presents
@@ -145,7 +159,9 @@ def test_query_for_current_user(car_factory, db, human_factory):
     db.session.commit()
 
     # success
-    with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock:
+    with patch(
+        "smorest_crud.access_control.utils._get_current_user"
+    ) as get_current_user_mock:
         get_current_user_mock.return_value = car_1.owner
         car = query_for_current_user(Car).all()
         assert len(car) == 1
@@ -160,7 +176,9 @@ def test_query_for_current_user(car_factory, db, human_factory):
     fake_human = human_factory()
     db.session.add(fake_human)
     db.session.commit()
-    with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock:
+    with patch(
+        "smorest_crud.access_control.utils._get_current_user"
+    ) as get_current_user_mock:
         get_current_user_mock.return_value = fake_human
         car = query_for_current_user(Car).all()
         assert len(car) == 0

--- a/smorest_crud/test/test_access_controls.py
+++ b/smorest_crud/test/test_access_controls.py
@@ -39,36 +39,39 @@ def test_get_for_user_or_404(car_factory, db):
     db.session.commit()
 
     # getting instance with success
-    car = Car.get_for_user_or_404(car_1.owner, car_1.id, key_attr="id")
+    car = Car.get_for_user_or_404(car_1.owner, car_1.id)
     assert car
     assert car == car_1
 
-    car = Car.get_for_user_or_404(car_2.owner, car_2.id, key_attr="id")
+    car = Car.get_for_user_or_404(car_2.owner, car_2.id)
     assert car
     assert car == car_2
 
     # getting not accessible instance with aborting
     with patch("smorest_crud.access_control.models.abort") as abort_mock:
-        car = Car.get_for_user_or_404(car_1.owner, car_2.id, key_attr="id")
+        car = Car.get_for_user_or_404(car_1.owner, car_2.id)
         assert car is None
         assert abort_mock.called_once_with(404)
 
     with patch("smorest_crud.access_control.models.abort") as abort_mock:
-        car = Car.get_for_user_or_404(car_2.owner, car_1.id, key_attr="id")
+        car = Car.get_for_user_or_404(car_2.owner, car_1.id)
         assert car is None
         assert abort_mock.called_once_with(404)
 
     # trying to get not existing instance
     with patch("smorest_crud.access_control.models.abort") as abort_mock:
-        car = Car.get_for_user_or_404(car_2.owner, car_2.id + 10, key_attr="id")
+        car = Car.get_for_user_or_404(car_2.owner, car_2.id + 10)
         assert car is None
         assert abort_mock.called_once_with(404)
 
 
-def test_get_for_user_or_404_no_attr(car_factory, db):
+def test_get_for_user_or_404_no_attr(car_factory, db, app):
     car = car_factory()
     db.session.add(car)
     db.session.commit()
+
+    # setting not existing column name in extension setup
+    app.extensions["crud"].key_attr = "extid"
 
     # trying to get not existing column
     with pytest.raises(AttributeError) as e:
@@ -85,13 +88,13 @@ def test_get_for_current_user_or_404(car_factory, db):
     # getting instance with success
     with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock:
         get_current_user_mock.return_value = car_1.owner
-        car = get_for_current_user_or_404(Car, car_1.id, key_attr="id")
+        car = get_for_current_user_or_404(Car, car_1.id)
         assert car
         assert car == car_1
 
     with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock:
         get_current_user_mock.return_value = car_2.owner
-        car = get_for_current_user_or_404(Car, car_2.id, key_attr="id")
+        car = get_for_current_user_or_404(Car, car_2.id)
         assert car
         assert car == car_2
 
@@ -99,14 +102,14 @@ def test_get_for_current_user_or_404(car_factory, db):
     with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock, \
             patch("smorest_crud.access_control.models.abort") as abort_mock:
         get_current_user_mock.return_value = car_2.owner
-        car = get_for_current_user_or_404(Car, car_1.id, key_attr="id")
+        car = get_for_current_user_or_404(Car, car_1.id)
         assert car is None
         assert abort_mock.called_once_with(404)
 
     with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock, \
             patch("smorest_crud.access_control.models.abort") as abort_mock:
         get_current_user_mock.return_value = car_1.owner
-        car = get_for_current_user_or_404(Car, car_2.id, key_attr="id")
+        car = get_for_current_user_or_404(Car, car_2.id)
         assert car is None
         assert abort_mock.called_once_with(404)
 
@@ -114,15 +117,18 @@ def test_get_for_current_user_or_404(car_factory, db):
     with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock, \
             patch("smorest_crud.access_control.models.abort") as abort_mock:
         get_current_user_mock.return_value = car_1.owner
-        car = get_for_current_user_or_404(Car, car_1.id + 10, key_attr="id")
+        car = get_for_current_user_or_404(Car, car_1.id + 10)
         assert car is None
         assert abort_mock.called_once_with(404)
 
 
-def test_get_for_current_user_or_404_no_attr(car_factory, db):
+def test_get_for_current_user_or_404_no_attr(car_factory, db, app):
     car = car_factory()
     db.session.add(car)
     db.session.commit()
+
+    # setting not existing column name in extension setup
+    app.extensions["crud"].key_attr = "extid"
 
     # trying to get not existing column
     with pytest.raises(AttributeError) as e, \

--- a/smorest_crud/test/test_access_controls.py
+++ b/smorest_crud/test/test_access_controls.py
@@ -1,4 +1,10 @@
+from unittest.mock import patch
+
+import pytest
 from flask.testing import FlaskClient
+
+from smorest_crud import get_for_current_user_or_404, query_for_current_user
+from smorest_crud.test.app import Car
 
 
 def test_create(client: FlaskClient, client_unauthenticated: FlaskClient):
@@ -25,3 +31,130 @@ def test_update(client: FlaskClient, pets):
 def test_list_no_acl(client: FlaskClient):
     res = client.get("/human/car")
     assert res.status_code == 200
+
+
+def test_get_for_user_or_404(car_factory, db):
+    car_1, car_2 = car_factory.create_batch(2)
+    db.session.add_all([car_1, car_2])
+    db.session.commit()
+
+    # getting instance with success
+    car = Car.get_for_user_or_404(car_1.owner, car_1.id, key_attr="id")
+    assert car
+    assert car == car_1
+
+    car = Car.get_for_user_or_404(car_2.owner, car_2.id, key_attr="id")
+    assert car
+    assert car == car_2
+
+    # getting not accessible instance with aborting
+    with patch("smorest_crud.access_control.models.abort") as abort_mock:
+        car = Car.get_for_user_or_404(car_1.owner, car_2.id, key_attr="id")
+        assert car is None
+        assert abort_mock.called_once_with(404)
+
+    with patch("smorest_crud.access_control.models.abort") as abort_mock:
+        car = Car.get_for_user_or_404(car_2.owner, car_1.id, key_attr="id")
+        assert car is None
+        assert abort_mock.called_once_with(404)
+
+    # trying to get not existing instance
+    with patch("smorest_crud.access_control.models.abort") as abort_mock:
+        car = Car.get_for_user_or_404(car_2.owner, car_2.id + 10, key_attr="id")
+        assert car is None
+        assert abort_mock.called_once_with(404)
+
+
+def test_get_for_user_or_404_no_attr(car_factory, db):
+    car = car_factory()
+    db.session.add(car)
+    db.session.commit()
+
+    # trying to get not existing column
+    with pytest.raises(AttributeError) as e:
+        Car.get_for_user_or_404(car.owner, car.id)
+        assert "extid" in e  # checking column name presents
+        assert "Car" in e  # checking class name presents
+
+
+def test_get_for_current_user_or_404(car_factory, db):
+    car_1, car_2 = car_factory.create_batch(2)
+    db.session.add_all([car_1, car_2])
+    db.session.commit()
+
+    # getting instance with success
+    with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock:
+        get_current_user_mock.return_value = car_1.owner
+        car = get_for_current_user_or_404(Car, car_1.id, key_attr="id")
+        assert car
+        assert car == car_1
+
+    with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock:
+        get_current_user_mock.return_value = car_2.owner
+        car = get_for_current_user_or_404(Car, car_2.id, key_attr="id")
+        assert car
+        assert car == car_2
+
+    # getting not accessible instance with aborting
+    with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock, \
+            patch("smorest_crud.access_control.models.abort") as abort_mock:
+        get_current_user_mock.return_value = car_2.owner
+        car = get_for_current_user_or_404(Car, car_1.id, key_attr="id")
+        assert car is None
+        assert abort_mock.called_once_with(404)
+
+    with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock, \
+            patch("smorest_crud.access_control.models.abort") as abort_mock:
+        get_current_user_mock.return_value = car_1.owner
+        car = get_for_current_user_or_404(Car, car_2.id, key_attr="id")
+        assert car is None
+        assert abort_mock.called_once_with(404)
+
+    # trying to get not existing instance
+    with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock, \
+            patch("smorest_crud.access_control.models.abort") as abort_mock:
+        get_current_user_mock.return_value = car_1.owner
+        car = get_for_current_user_or_404(Car, car_1.id + 10, key_attr="id")
+        assert car is None
+        assert abort_mock.called_once_with(404)
+
+
+def test_get_for_current_user_or_404_no_attr(car_factory, db):
+    car = car_factory()
+    db.session.add(car)
+    db.session.commit()
+
+    # trying to get not existing column
+    with pytest.raises(AttributeError) as e, \
+            patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock:
+        get_current_user_mock.return_value = car.owner
+        get_for_current_user_or_404(Car, car.id)
+        assert "extid" in e  # checking column name presents
+        assert "Car" in e  # checking class name presents
+
+
+def test_query_for_current_user(car_factory, db, human_factory):
+    car_1, car_2 = car_factory.create_batch(2)
+    db.session.add_all([car_1, car_2])
+    db.session.commit()
+
+    # success
+    with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock:
+        get_current_user_mock.return_value = car_1.owner
+        car = query_for_current_user(Car).all()
+        assert len(car) == 1
+        assert car[0] == car_1
+
+        get_current_user_mock.return_value = car_2.owner
+        car = query_for_current_user(Car).all()
+        assert len(car) == 1
+        assert car[0] == car_2
+
+    # failure
+    fake_human = human_factory()
+    db.session.add(fake_human)
+    db.session.commit()
+    with patch("smorest_crud.access_control.utils._get_current_user") as get_current_user_mock:
+        get_current_user_mock.return_value = fake_human
+        car = query_for_current_user(Car).all()
+        assert len(car) == 0

--- a/smorest_crud/view.py
+++ b/smorest_crud/view.py
@@ -5,12 +5,11 @@ from flask_sqlalchemy import BaseQuery, Model, SQLAlchemy
 from sqlalchemy.orm import RelationshipProperty, joinedload
 from functools import reduce
 from flask_jwt_extended import jwt_required
-from smorest_crud import _crud, AccessControlUser
+from smorest_crud import _crud, config_keys
+from smorest_crud.access_control import AccessControlUser
 import logging
 
 log = logging.getLogger(__name__)
-
-config_keys = dict(get_user="CRUD_GET_USER")
 
 
 class CRUDView(MethodView):


### PR DESCRIPTION
## Briefly
Updated existing access control handling. Added supporting of base queries for models, `get_for_user_or_404` method for `AccessControlUser` and a couple of util functions.
## Description
First of all, added `AccessControlQuery` with `query_for_user` method inside. This way of things is more obvious and flexible. But `query_for_user` method on `AccessControlUser` was left to not bring any critical changes. Also, was added a quite useful method `get_for_user_or_404` which have similar use-cases as `get_by_extid_or_404` but also performing read access check on selected instance. 
Added two util functions for access control. `get_for_current_user_or_404` which will try to get the instance of the given model by the given column name for the current user. The function will use the column name setted in the app config under the `CRUD_KEY_COLUMN` key with the default value `id`. A similar idea about `query_for_current_user` but this function will return the query for the current user for further updating.
Made some refactoring and moved all access related models/function to a separate package because it looks like a quite big part of the library and having them in the main init file is not the best solution IMHO.
## Tests
Added tests for new methods and functions, everything is working. 
`test_get_for_user_or_404`, `test_get_for_user_or_404_no_attr`, `test_get_for_current_user_or_404`, `test_get_for_current_user_or_404_no_attr`, `test_query_for_current_user`